### PR TITLE
Update download links for Omni Core 0.2.0

### DIFF
--- a/download.html
+++ b/download.html
@@ -61,43 +61,43 @@ https://en.wikipedia.org/wiki/Tourism_in_Perth#/media/File:Perth_city_scape.jpg
                     <div class="col-md-4">
                       <h3 class="text-center">Mac OS X (Client only)</h3>
                       <ul class="plan">
-                        <li class="plan-action"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.0.12.0-rel-osx-unsigned.dmg" class="btn btn-primary btn-lg">Download</a></li>
+                        <li class="plan-action"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.2.0-osx-unsigned.dmg" class="btn btn-primary btn-lg">Download</a></li>
                         <li class="plan-small">Verify Sha256 Sum:</li>
-                        <li class="plan-fine">4b9f6837bc75a20a310ad4fadd9920ef10f9dc59d810acf9cfcacf0cf67d986d</li>
+                        <li class="plan-fine">7a95f0d7bd3aa4c9b8d554963fd05c3d50015cf913de06bd8cc11968819c5fd6</li>
                       </ul>
                       <h3 class="text-center">Mac OS X (Client &amp; Server)</h3>
                       <ul class="plan">
-                        <li class="plan-action"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.0.12.0-rel-osx64.tar.gz" class="btn btn-primary btn-lg">Download</a></li>
+                        <li class="plan-action"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.2.0-osx64.tar.gz" class="btn btn-primary btn-lg">Download</a></li>
                         <li class="plan-small">Verify Sha256 Sum:</li>
-                        <li class="plan-fine">8d8f8c3d3fcc240293043d502e1511af5a63a20d35f84454fd07217e5bda69e9</li>
+                        <li class="plan-fine">da46f817d2c1e2c17dd02a3cbb0f5b0d3da41ac80c5245de2af73714704a008c</li>
                       </ul>
                     </div>
                     <div class="col-md-4">
                       <h3 class="text-center">32-bit Windows</h3>
                       <ul class="plan">
-                        <li class="plan-action"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.0.12.0-rel-win32-setup.exe" class="btn btn-primary btn-lg">Download</a></li>
+                        <li class="plan-action"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.2.0.0-win32-setup-unsigned.exe" class="btn btn-primary btn-lg">Download</a></li>
                         <li class="plan-small">Verify Sha256 Sum:</li>
-                        <li class="plan-fine">37b5bbcd49c16cab19d3a622a9e4295d0498b596b62d58cf7b933a8947eb5332</li>
+                        <li class="plan-fine">fc030680cd9d7a334541708bdc58f8bd24e9b531949f20e54409088bba5ca69f</li>
                       </ul>
                       <h3 class="text-center">64-bit Windows</h3>
                       <ul class="plan">
-                        <li class="plan-action"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.0.12.0-rel-win64-setup.exe" class="btn btn-primary btn-lg">Download</a></li>
+                        <li class="plan-action"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.2.0.0-win64-setup-unsigned.exe" class="btn btn-primary btn-lg">Download</a></li>
                         <li class="plan-small">Verify Sha256 Sum:</li>
-                        <li class="plan-fine">661795bf22213a064a955813bf22cee8097bfbf7fbe328c4e6d4551504dd9e6f</li>
+                        <li class="plan-fine">2bdfd3557681efd2a85698ffcb68b192d72e857fe00ce7a0076b31d152beeed2</li>
                       </ul>
                     </div>
                     <div class="col-md-4">
                       <h3 class="text-center">32-bit Linux</h3>
                       <ul class="plan">
-                        <li class="plan-action"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.0.12.0-rel-linux32.tar.gz" class="btn btn-primary btn-lg">Download</a></li>
+                        <li class="plan-action"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.2.0-i686-pc-linux-gnu.tar.gz" class="btn btn-primary btn-lg">Download</a></li>
                         <li class="plan-small">Verify Sha256 Sum:</li>
-                        <li class="plan-fine">98c7b3dfa79fe154df30d8eeec834459e33f44441b6b0e3859fe2c30e29cd49f</li>
+                        <li class="plan-fine">fb9db5043f4fba8756a514341c3907434d1dd833f369eeb2fbf7fdccd5a87d90</li>
                       </ul>
                       <h3 class="text-center">64-bit Linux</h3>
                       <ul class="plan">
-                        <li class="plan-action"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.0.12.0-rel-linux64.tar.gz" class="btn btn-primary btn-lg">Download</a></li>
+                        <li class="plan-action"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.2.0-x86_64-linux-gnu.tar.gz" class="btn btn-primary btn-lg">Download</a></li>
                         <li class="plan-small">Verify Sha256 Sum:</li>
-                        <li class="plan-fine">33b8d0a747c7f7fa74a4e8a21221d49a4c0f9ba0bb50886509ef5b9265961a36</li>
+                        <li class="plan-fine">752b64164b92337c31c924592c05094495052f7532c300934789740d03bb48e8</li>
                       </ul>
                     </div>
                 </div>


### PR DESCRIPTION
This pull request updates the download links for Omni Core 0.2.0.

You can confirm the files and file hashes by looking at the .asset files in the gitian.sigs repo. In particular:

- https://github.com/OmniLayer/gitian.sigs/blob/master/0.2.0-linux/zathras/omnicore-linux-0.13-build.assert
- https://github.com/OmniLayer/gitian.sigs/blob/master/0.2.0-linux/dexX7/omnicore-linux-0.13-build.assert
- https://github.com/OmniLayer/gitian.sigs/blob/master/0.2.0-osx-unsigned/zathras/omnicore-osx-0.13-build.assert
- https://github.com/OmniLayer/gitian.sigs/blob/master/0.2.0-osx-unsigned/dexX7/omnicore-osx-0.13-build.assert
- https://github.com/OmniLayer/gitian.sigs/blob/master/0.2.0-win/zathras/omnicore-win-0.13-build.assert
- https://github.com/OmniLayer/gitian.sigs/blob/master/0.2.0-win/dexX7/omnicore-win-0.13-build.assert