### PR TITLE
Update download links for Omni Core 0.3.1

### DIFF
--- a/download.html
+++ b/download.html
@@ -60,9 +60,9 @@
             <div class="cardtext">
               <h3 class="heading-4">Mac OS X (Client only)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">aef00bf6b18405de90b3fb96f803cf3ebcf6c60706168eda6bc46eeb9e3ee778</div>
+              <div class="shasum">3f7c65f907deb9faa1f7347979f892594966a00193a5538a1cd9f8717e416240</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.0-osx-unsigned.dmg" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.1-osx-unsigned.dmg" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
@@ -70,9 +70,9 @@
             <div class="cardtext">
               <h3 class="heading-4">32-bit Windows</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">618963dfaaa23774109364590bb37f28480d7f1c02caa0f1d12f70182535839a</div>
+              <div class="shasum">4fb605d449ae6811a2a6d56afd07e74829270eee1f985f751fa01013e48ec329</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.0.0-win32-setup-unsigned.exe" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.1.0-win32-setup-unsigned.exe" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
@@ -80,9 +80,9 @@
             <div class="cardtext">
               <h3 class="heading-4">32-bit Linux</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">ca381cb956eb86046417bcb3a5135da205cee96e04be8f5f031774bbbafc9c1f</div>
+              <div class="shasum">0a611bba04ca815c352fc59e86280d3f5659b4681c6ffd032648eca2c836cbb2</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.0-i686-pc-linux-gnu.tar.gz" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.1-i686-pc-linux-gnu.tar.gz" class="link">Download</a></div>
           </div>
         </div>
       </div>
@@ -92,9 +92,9 @@
             <div class="cardtext">
               <h3 class="heading-4">Mac OS X (Client &amp; Server)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">66e049051514ae6986bc0aaeab890760eb4733ea1da3e4c6e76ce726d7e75dd7</div>
+              <div class="shasum">4cbcc9bcbf105d6a3eb9c32a5ead46b63c274f97336cdee473c6cdd8f2783060</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.0-osx64.tar.gz" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.1-osx64.tar.gz" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
@@ -103,8 +103,8 @@
               <h3 class="heading-4">64-bit Windows</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
             </div>
-            <div class="shasum">d53eb6a42a9f15b1c9c991592beb6a1e6ad1e4d7e84202b3c360a759cb710e4d</div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.0.0-win64-setup-unsigned.exe" class="link">Download</a></div>
+            <div class="shasum">5dc4572362e86f94df8014a64dcc446b98b7fa7876f00eb6044c4568a8230d12</div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.1.0-win64-setup-unsigned.exe" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
@@ -112,9 +112,9 @@
             <div class="cardtext">
               <h3 class="heading-4">64-bit Linux</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">fc25774b74fe9a7d329cc53327e1079cfa548988e09d3225c2fe07b6d6225161</div>
+              <div class="shasum">a47e5ef005dcc9d38fbc134c06dba6ce82b87360decabb78784e829306e8b68e</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.0-x86_64-linux-gnu.tar.gz" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.1-x86_64-linux-gnu.tar.gz" class="link">Download</a></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This pull request updates the download links for Omni Core 0.3.1.

The hashes and files can be compared on Bitray and in our gitian.sigs repository:

- https://github.com/OmniLayer/gitian.sigs/blob/master/0.3.1-win/Adam/omnicore-win-0.13-build.assert
- https://github.com/OmniLayer/gitian.sigs/blob/master/0.3.1-osx-unsigned/Adam/omnicore-osx-0.13-build.assert
- https://github.com/OmniLayer/gitian.sigs/blob/master/0.3.1-linux/Adam/omnicore-linux-0.13-build.assert