### PR TITLE
Update download links for Omni Core 0.4.0

### DIFF
--- a/download.html
+++ b/download.html
@@ -40,7 +40,7 @@
       <div class="w-col w-col-3"></div>
       <div class="column w-col w-col-6">
         <h1 class="heading subpageh2">Download Omni Core</h1>
-        <p class="heroparagraph">Latest version: Omni Core 0.3.1</p>
+        <p class="heroparagraph">Latest version: Omni Core 0.4.0</p>
       </div>
       <div class="w-col w-col-3"></div>
     </div>
@@ -60,29 +60,29 @@
             <div class="cardtext">
               <h3 class="heading-4">Mac OS X (Client only)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">3f7c65f907deb9faa1f7347979f892594966a00193a5538a1cd9f8717e416240</div>
+              <div class="shasum">cf35bc421e3e67b37e9330f3a361fedd6794f6c2ebf606240b1dba02b73a4ed0</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.1-osx-unsigned.dmg" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.4.0-osx-unsigned.dmg" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
           <div class="cardblock projects">
             <div class="cardtext">
-              <h3 class="heading-4">32-bit Windows</h3>
+              <h3 class="heading-4">64-bit Windows</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">4fb605d449ae6811a2a6d56afd07e74829270eee1f985f751fa01013e48ec329</div>
+              <div class="shasum">2d76bd94612a6671ba9ae3dd94e687a8420559ad1b37109e394f9e14b75f3e02</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.1.0-win32-setup-unsigned.exe" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.4.0.0-win64-setup-unsigned.exe" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
           <div class="cardblock projects">
             <div class="cardtext">
-              <h3 class="heading-4">32-bit Linux</h3>
+              <h3 class="heading-4">64-bit Linux</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">0a611bba04ca815c352fc59e86280d3f5659b4681c6ffd032648eca2c836cbb2</div>
+              <div class="shasum">03f0da007c70d68fee28641c1ea56566f5d7debbc2858d99977bda409643959a</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.1-i686-pc-linux-gnu.tar.gz" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.4.0-x86_64-linux-gnu.tar.gz" class="link">Download</a></div>
           </div>
         </div>
       </div>
@@ -92,29 +92,29 @@
             <div class="cardtext">
               <h3 class="heading-4">Mac OS X (Client &amp; Server)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">4cbcc9bcbf105d6a3eb9c32a5ead46b63c274f97336cdee473c6cdd8f2783060</div>
+              <div class="shasum">d6ff3955db1e2971c4ad6fd77136f79a766a45e149d816addcb975b0c11fcf63</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.1-osx64.tar.gz" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.4.0-osx64.tar.gz" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
           <div class="cardblock projects">
             <div class="cardtext">
-              <h3 class="heading-4">64-bit Windows</h3>
+              <h3 class="heading-4">64-bit ARM</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
             </div>
-            <div class="shasum">5dc4572362e86f94df8014a64dcc446b98b7fa7876f00eb6044c4568a8230d12</div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.1.0-win64-setup-unsigned.exe" class="link">Download</a></div>
+            <div class="shasum">d835edd487a2559dd9de6f0526eb1bf454bf62d9e2a7984f55e0e739c3113136</div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.4.0-aarch64-linux-gnu.tar.gz" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
           <div class="cardblock projects">
             <div class="cardtext">
-              <h3 class="heading-4">64-bit Linux</h3>
-              <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">a47e5ef005dcc9d38fbc134c06dba6ce82b87360decabb78784e829306e8b68e</div>
+              <h3 class="heading-4">Source Code on GitHub</h3>
+              <p class="projectsparagraph">&nbsp;</p>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.3.1-x86_64-linux-gnu.tar.gz" class="link">Download</a></div>
+            <div class="shasum">&nbsp;</div>
+            <div class="cardlink download"><a href="https://github.com/OmniLayer/omnicore" class="link">Go to GitHub</a></div>
           </div>
         </div>
       </div>
@@ -148,7 +148,7 @@
       <div class="w-row">
         <div class="w-col w-col-6">
           <div class="copyrightleft">
-            <div class="copyright-text-left">© 2017 Omni Team.  All Rights Reserved.</div>
+            <div class="copyright-text-left">© 2019 Omni Team.  All Rights Reserved.</div>
           </div>
         </div>
         <div class="w-col w-col-6">


### PR DESCRIPTION
This pull request updates the download links for Omni Core v0.4.0 and removes unsupported 32 bit versions. A link to GitHub is also added.

![image](https://user-images.githubusercontent.com/5836089/52935135-d5494c00-3358-11e9-90e2-724d234e0fe3.png)

The hashes and files can be compared on Bitray and in our gitian.sigs repository:

- https://github.com/OmniLayer/gitian.sigs/blob/master/0.3.1-win/Adam/omnicore-win-0.13-build.assert
- https://github.com/OmniLayer/gitian.sigs/blob/master/0.3.1-osx-unsigned/Adam/omnicore-osx-0.13-build.assert
- https://github.com/OmniLayer/gitian.sigs/blob/master/0.3.1-linux/Adam/omnicore-linux-0.13-build.assert