### PR TITLE
Update download links for Omni Core 0.5.0

### DIFF
--- a/download.html
+++ b/download.html
@@ -40,7 +40,7 @@
       <div class="w-col w-col-3"></div>
       <div class="column w-col w-col-6">
         <h1 class="heading subpageh2">Download Omni Core</h1>
-        <p class="heroparagraph">Latest version: Omni Core 0.4.0</p>
+        <p class="heroparagraph">Latest version: Omni Core 0.5.0</p>
       </div>
       <div class="w-col w-col-3"></div>
     </div>
@@ -60,9 +60,9 @@
             <div class="cardtext">
               <h3 class="heading-4">Mac OS X (Client only)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">cf35bc421e3e67b37e9330f3a361fedd6794f6c2ebf606240b1dba02b73a4ed0</div>
+              <div class="shasum">72079784802da29b1dd5afdbad27c917fbb8dc9c77908b411d3c223e5f61aaa1</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.4.0-osx-unsigned.dmg" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.5.0-osx-unsigned.dmg" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
@@ -70,9 +70,9 @@
             <div class="cardtext">
               <h3 class="heading-4">64-bit Windows</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">2d76bd94612a6671ba9ae3dd94e687a8420559ad1b37109e394f9e14b75f3e02</div>
+              <div class="shasum">19e6cfc9e2b6b59155aa7cf9c07b75a17ba5092246979358eebc458402df1f35</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.4.0.0-win64-setup-unsigned.exe" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.5.0.0-win64-setup-unsigned.exe" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
@@ -80,9 +80,9 @@
             <div class="cardtext">
               <h3 class="heading-4">64-bit Linux</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">03f0da007c70d68fee28641c1ea56566f5d7debbc2858d99977bda409643959a</div>
+              <div class="shasum">fd72e4c0b35684883ad20bac556ead57d9c6e63398b90f9734fd19c788bfe2f0</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.4.0-x86_64-linux-gnu.tar.gz" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.5.0-x86_64-linux-gnu.tar.gz" class="link">Download</a></div>
           </div>
         </div>
       </div>
@@ -92,9 +92,9 @@
             <div class="cardtext">
               <h3 class="heading-4">Mac OS X (Client &amp; Server)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">d6ff3955db1e2971c4ad6fd77136f79a766a45e149d816addcb975b0c11fcf63</div>
+              <div class="shasum">1fd15ee116eec10b7c41179b464d7d9813030c046dae96ed23c17aafffd3301a</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.4.0-osx64.tar.gz" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.5.0-osx64.tar.gz" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
@@ -103,8 +103,8 @@
               <h3 class="heading-4">64-bit ARM</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
             </div>
-            <div class="shasum">d835edd487a2559dd9de6f0526eb1bf454bf62d9e2a7984f55e0e739c3113136</div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.4.0-aarch64-linux-gnu.tar.gz" class="link">Download</a></div>
+            <div class="shasum">cb7049c52ace796e7406c531c454459a19eefa6c3ba6b855bc9d766ce1426bdb</div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.5.0-aarch64-linux-gnu.tar.gz" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">


### PR DESCRIPTION
This pull request updates the download links for Omni Core v0.5.0:

![image](https://user-images.githubusercontent.com/5836089/57065726-a6d9dc80-6cca-11e9-8ab2-a763f7d3a67d.png)
