### PR TITLE
Update download links for Omni Core 0.7.1

### DIFF
--- a/download.html
+++ b/download.html
@@ -40,7 +40,7 @@
       <div class="w-col w-col-3"></div>
       <div class="column w-col w-col-6">
         <h1 class="heading subpageh2">Download Omni Core</h1>
-        <p class="heroparagraph">Latest version: Omni Core 0.7.0</p>
+        <p class="heroparagraph">Latest version: Omni Core 0.7.1</p>
       </div>
       <div class="w-col w-col-3"></div>
     </div>
@@ -50,7 +50,7 @@
   <div class="downloadbody">
     <div class="container-11 w-container">
       <div>
-        <div class="text-block-4">Omni Core is a fast, portable Omni Layer implementation that is based off the Bitcoin Core codebase (currently 0.13). This implementation requires no external dependencies extraneous to Bitcoin Core, and is native to the Bitcoin network just like other Bitcoin nodes. It currently supports a wallet mode and is seamlessly available on three platforms: Windows, Linux and Mac OS. Omni Layer extensions are exposed via the JSON-RPC interface. Development has been consolidated on the Omni Core product, and it is the reference client for the Omni Layer.</div>
+        <div class="text-block-4">Omni Core is a fast, portable Omni Layer implementation that is based off the Bitcoin Core codebase (currently 0.18). This implementation requires no external dependencies extraneous to Bitcoin Core, and is native to the Bitcoin network just like other Bitcoin nodes. It currently supports a wallet mode and is seamlessly available on three platforms: Windows, Linux and Mac OS. Omni Layer extensions are exposed via the JSON-RPC interface. Development has been consolidated on the Omni Core product, and it is the reference client for the Omni Layer.</div>
       </div>
     </div>
     <div class="container-10 w-container">
@@ -60,19 +60,19 @@
             <div class="cardtext">
               <h3 class="heading-4">Mac OS X (Client only)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">8e91866073028109ba1847bfefc774ea2cd9a68769b3618e8d4731c4ecddc59e</div>
+              <div class="shasum">85bc5cd184d30d7ef9ffea3f6a173d0737b1dc964b992294cd64e969a2c88131</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.7.0-osx-unsigned.dmg" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.7.1-osx-unsigned.dmg" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
           <div class="cardblock projects">
             <div class="cardtext">
-              <h3 class="heading-4">64-bit Windows</h3>
+              <h3 class="heading-4">64-bit Windows (Installer)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">85d533daf8aeb0289363265f62b3f7d84fbc2d993b630801e084c061ed6413fe</div>
+              <div class="shasum">0766c0bddbbeb8174a637096b2c76b3789bd2b854cd403a5cbdca3ad889a5b76</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.7.0.0-win64-setup-unsigned.exe" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.7.1.0-win64-setup-unsigned.exe" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
@@ -80,9 +80,9 @@
             <div class="cardtext">
               <h3 class="heading-4">64-bit Linux</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">db71b1e3f135bd713c8c8e91738834d538fad8a5676036aa6bbdb6f5197bbe59</div>
+              <div class="shasum">c2334e2d776ac0324c91f5e4fd631183e7ee2841ca47ad51d0048ce022e9cdf2</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.7.0-x86_64-linux-gnu.tar.gz" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.7.1-x86_64-linux-gnu.tar.gz" class="link">Download</a></div>
           </div>
         </div>
       </div>
@@ -92,9 +92,19 @@
             <div class="cardtext">
               <h3 class="heading-4">Mac OS X (Client &amp; Server)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">fa61cf373fc74e1b89fa86004d1f64727f73ab320366febbaa714ef93250e728</div>
+              <div class="shasum">19232f9c730c1b68b6dd267a7c92bac3e99b82e67cb5c5249dbdea9b3998bf31</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.7.0-osx64.tar.gz" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.7.1-osx64.tar.gz" class="link">Download</a></div>
+          </div>
+        </div>
+        <div class="w-col w-col-4">
+          <div class="cardblock projects">
+            <div class="cardtext">
+              <h3 class="heading-4">64-bit Windows (files only)</h3>
+              <p class="projectsparagraph">Verify Sha256 Sum:</p>
+            </div>
+            <div class="shasum">e4fc738d355d366427af784e485235560def1fb2702ec90e77196f29462d37fb</div>
+            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.7.1-win64.zip" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
@@ -138,7 +148,7 @@
       <div class="w-row">
         <div class="w-col w-col-6">
           <div class="copyrightleft">
-            <div class="copyright-text-left">© 2019 Omni Team.  All Rights Reserved.</div>
+            <div class="copyright-text-left">© 2020 Omni Team.  All Rights Reserved.</div>
           </div>
         </div>
         <div class="w-col w-col-6">


### PR DESCRIPTION
This pull request updates the download links for Omni Core v0.7.1:

![image](https://user-images.githubusercontent.com/5836089/72798549-9fd17080-3c43-11ea-991a-76186bd8a583.png)

It also adds back the download link for the Windows 64 bit files only, without a setup/installer.