### PR TITLE
Update download links for Omni Core 0.10.0

### DIFF
--- a/download.html
+++ b/download.html
@@ -40,7 +40,7 @@
       <div class="w-col w-col-3"></div>
       <div class="column w-col w-col-6">
         <h1 class="heading subpageh2">Download Omni Core</h1>
-        <p class="heroparagraph">Latest version: Omni Core 0.9.0</p>
+        <p class="heroparagraph">Latest version: Omni Core 0.10.0</p>
       </div>
       <div class="w-col w-col-3"></div>
     </div>
@@ -50,7 +50,7 @@
   <div class="downloadbody">
     <div class="container-11 w-container">
       <div>
-        <div class="text-block-4">Omni Core is a fast, portable Omni Layer implementation that is based off the Bitcoin Core codebase (currently 0.18). This implementation requires no external dependencies extraneous to Bitcoin Core, and is native to the Bitcoin network just like other Bitcoin nodes. It currently supports a wallet mode and is seamlessly available on three platforms: Windows, Linux and Mac OS. Omni Layer extensions are exposed via the JSON-RPC interface. Development has been consolidated on the Omni Core product, and it is the reference client for the Omni Layer.</div>
+        <div class="text-block-4">Omni Core is a fast, portable Omni Layer implementation that is based off the Bitcoin Core codebase (currently 0.20.1). This implementation requires no external dependencies extraneous to Bitcoin Core, and is native to the Bitcoin network just like other Bitcoin nodes. It currently supports a wallet mode and is seamlessly available on three platforms: Windows, Linux and Mac OS. Omni Layer extensions are exposed via the JSON-RPC interface. Development has been consolidated on the Omni Core product, and it is the reference client for the Omni Layer.</div>
       </div>
     </div>
     <div class="container-10 w-container">
@@ -60,9 +60,9 @@
             <div class="cardtext">
               <h3 class="heading-4">Mac OS X (Client only)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">5449353da441c39862535802368ff151a95f968ea84b6239db10b67aa2c25b16</div>
+              <div class="shasum">094511a963293d55f4c666b01634afc96901a355724bbc7d2b95ad5050fe945a</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.9.0-osx-unsigned.dmg" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://github.com/OmniLayer/omnicore/releases/download/v0.10.0/omnicore-0.10.0-osx-unsigned.dmg" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
@@ -70,9 +70,9 @@
             <div class="cardtext">
               <h3 class="heading-4">64-bit Windows (Installer)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">9088a729a83bf467cb505d25fca2ecc93e0cddf8f4b2438a774405fdc6b45b4d</div>
+              <div class="shasum">19fd6497f1c0986ce99448d3f6a17b30ffcff4ee54277e275c2f65c55d7f252a</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.9.0.0-win64-setup-unsigned.exe" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://github.com/OmniLayer/omnicore/releases/download/v0.10.0/omnicore-0.10.0.0-win64-setup-unsigned.exe" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
@@ -80,9 +80,9 @@
             <div class="cardtext">
               <h3 class="heading-4">64-bit Linux</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">70adddaff52e597975fa5ebee1642be95664f21c7e356d5c931dc4ea8a112fb9</div>
+              <div class="shasum">e967aeba3a8a66073617f1d5564a99bf21cdaf1d20bb03330d5f8fa17902ba82</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.9.0-x86_64-linux-gnu.tar.gz" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://github.com/OmniLayer/omnicore/releases/download/v0.10.0/omnicore-0.10.0-x86_64-linux-gnu.tar.gz" class="link">Download</a></div>
           </div>
         </div>
       </div>
@@ -92,9 +92,9 @@
             <div class="cardtext">
               <h3 class="heading-4">Mac OS X (Client &amp; Server)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
-              <div class="shasum">1daefea0098fa8d4ff718b01c3dfc7fd2090014803744a5907a63fd5eef4d396</div>
+              <div class="shasum">d1fc85748bc4264c6013cd0c183c264713eae6363ce6011151fe33f026b5859c</div>
             </div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.9.0-osx64.tar.gz" class="link">Download</a></div>
+            <div class="cardlink download"><a href="https://github.com/OmniLayer/omnicore/releases/download/v0.10.0/omnicore-0.10.0-osx64.tar.gz" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">
@@ -103,8 +103,8 @@
               <h3 class="heading-4">64-bit Windows (files only)</h3>
               <p class="projectsparagraph">Verify Sha256 Sum:</p>
             </div>
-            <div class="shasum">0f2f616735f11268cf583cd2a7274e592aa51d03aa661c934a0249c1313a5571</div>
-            <div class="cardlink download"><a href="https://bintray.com/artifact/download/omni/OmniBinaries/omnicore-0.9.0-win64.zip" class="link">Download</a></div>
+            <div class="shasum">1becea6bf8d764cad191f0413c6c24fc6e01e0a7adc162c8284d51a036007986</div>
+            <div class="cardlink download"><a href="https://github.com/OmniLayer/omnicore/releases/download/v0.10.0/omnicore-0.10.0-win64.zip" class="link">Download</a></div>
           </div>
         </div>
         <div class="w-col w-col-4">


### PR DESCRIPTION
This pull request updates the download links for Omni Core 0.10.0.

Please note, binaries are no longer hosted in Bintray, but on Github.